### PR TITLE
Fix incorrect escaping of large payloads (focused PR)

### DIFF
--- a/lib/action_cable/subscription_adapter/enhanced_postgresql.rb
+++ b/lib/action_cable/subscription_adapter/enhanced_postgresql.rb
@@ -38,7 +38,6 @@ module ActionCable
 
         with_broadcast_connection do |pg_conn|
           channel = pg_conn.escape_identifier(channel_identifier(channel))
-          payload = pg_conn.escape_string(payload)
 
           if payload.bytesize > MAX_NOTIFY_SIZE
             payload_id = insert_large_payload(pg_conn, payload)
@@ -53,7 +52,7 @@ module ActionCable
             payload = "#{LARGE_PAYLOAD_PREFIX}#{encrypted_payload_id}"
           end
 
-          pg_conn.exec("NOTIFY #{channel}, '#{payload}'")
+          pg_conn.exec("NOTIFY #{channel}, #{pg_conn.escape_literal(payload)}")
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "debug"
-
-require "active_support/testing/strict_warnings"
+begin
+  require "active_support/testing/strict_warnings"
+rescue LoadError
+  nil
+end
 require "action_cable"
 require "active_support/testing/autorun"
 require "active_support/testing/method_call_assertions"


### PR DESCRIPTION
Extracts the bugfix of #5 while removing the Dockerized test setup changes. 

I was hopeful that the more focused change would be more palatable for merging upstream in case that added friction to reviewing the other PR. 

Fixes #4. 

I did make one test setup change 🥵  `active_support/testing/strict_warnings` was moved out of LOAD_PATH: https://github.com/rails/rails/pull/54617

(fyi @chriscz who authored #5)